### PR TITLE
Consul health check

### DIFF
--- a/start-cb.sh
+++ b/start-cb.sh
@@ -191,13 +191,12 @@ wait_for_service() {
     : ${service:? required}
 
     debug "wait for $service gets registered in consul ..."
-    local watchres=$( docker run -it --rm \
+    ( docker run -it --rm \
         --net container:consul \
         --entrypoint /bin/consul \
         sequenceiq/consul:v0.5.0 \
           watch -type=service -service=$service -passingonly=true bash -c 'cat|grep "\[\]" '
-    )
-    debug "[wait] watch result: $watchres"
+    ) &> /dev/null
     debug "$service is registered: $(dhp $service)"
 }
 

--- a/start-cb.sh
+++ b/start-cb.sh
@@ -284,7 +284,6 @@ start_cloudbreak() {
 
     docker run -d \
         --name=cloudbreak \
-        -e "SERVICE_NAME=cloudbreak" \
         -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
         -e AWS_SECRET_KEY=$AWS_SECRET_KEY \
         -e SERVICE_NAME=cloudbreak \

--- a/start-cb.sh
+++ b/start-cb.sh
@@ -167,6 +167,7 @@ start_consul() {
     docker run -d \
         -h node1 \
         --name=consul \
+        -e SERVICE_IGNORE=true \
         -p ${BRIDGE_IP}:53:53/udp \
         -p ${BRIDGE_IP}:8400:8400 \
         -p ${BRIDGE_IP}:8500:8500 \

--- a/start-cb.sh
+++ b/start-cb.sh
@@ -190,12 +190,15 @@ wait_for_service() {
     declare service=$1
     : ${service:? required}
 
-    ( docker run -it --rm \
+    debug "wait for $service gets registered in consul ..."
+    local watchres=$( docker run -it --rm \
         --net container:consul \
         --entrypoint /bin/consul \
         sequenceiq/consul:v0.5.0 \
-          watch -type=service -service=$service bash -c 'cat|grep "\[\]" '
-    ) &> /dev/null
+          watch -type=service -service=$service -passingonly=true bash -c 'cat|grep "\[\]" '
+    )
+    debug "[wait] watch result: $watchres"
+    debug "$service is registered: $(dhp $service)"
 }
 
 start_cloudbreak_db() {
@@ -229,6 +232,7 @@ start_uaa() {
     docker run -d -P \
       --name="uaa" \
       -e "SERVICE_NAME=uaa" \
+      -e SERVICE_CHECK_HTTP=/login \
       -e IDENTITY_DB_URL=$(dhp uaadb) \
       -v $PWD/uaa.yml:/uaa/uaa.yml \
       -v /var/lib/uaa/uaadb:/var/lib/postgresql/data \
@@ -288,6 +292,7 @@ start_cloudbreak() {
         -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
         -e AWS_SECRET_KEY=$AWS_SECRET_KEY \
         -e SERVICE_NAME=cloudbreak \
+        -e SERVICE_CHECK_HTTP=/info \
         -e CB_IDENTITY_SERVER_URL=http://$(dhp uaa) \
         -e CB_DB_PORT_5432_TCP_ADDR=$(dh cbdb) \
         -e CB_DB_PORT_5432_TCP_PORT=$(dp cbdb) \
@@ -306,6 +311,7 @@ start_uluwatu() {
     docker run -d --name uluwatu \
     -e ULU_PRODUCTION=false \
     -e SERVICE_NAME=uluwatu \
+    -e SERVICE_CHECK_HTTP=/ \
     -e ULU_CLOUDBREAK_ADDRESS=http://$(dhp cloudbreak) \
     -e ULU_OAUTH_REDIRECT_URI=$HOST_ADDRESS:3000/authorize \
     -e ULU_IDENTITY_ADDRESS=http://$(dhp uaa)/ \
@@ -323,6 +329,7 @@ start_sultans() {
     -e SL_CLIENT_ID=$UAA_SULTANS_ID \
     -e SL_CLIENT_SECRET=$UAA_SULTANS_SECRET \
     -e SERVICE_NAME=sultans \
+    -e SERVICE_CHECK_HTTP=/ \
     -e SL_PORT=3000 \
     -e SL_UAA_ADDRESS=http://$(dhp uaa) \
     -e SL_SMTP_SENDER_HOST=$CB_SMTP_SENDER_HOST \
@@ -355,6 +362,7 @@ start_periscope() {
     -e PERISCOPE_DB_HBM2DDL_STRATEGY=$PERISCOPE_DB_HBM2DDL_STRATEGY \
     -e PERISCOPE_DB_TCP_PORT=$(dp periscopedb) \
     -e SERVICE_NAME=periscope \
+    -e SERVICE_CHECK_HTTP=/info \
     -e PERISCOPE_DB_TCP_ADDR=$(dh periscopedb) \
     -e PERISCOPE_SMTP_HOST=$CB_SMTP_SENDER_HOST \
     -e PERISCOPE_SMTP_USERNAME=$CB_SMTP_SENDER_USERNAME \


### PR DESCRIPTION
define consul health checks via SERVICE_CHECK_HTTP metadata interpreted by registrator
## registrator

See registrator specific metadata explanation: https://github.com/gliderlabs/registrator#basic-http-health-check
## wait for service

The wait_for_service is a [consul watch](https://www.consul.io/docs/commands/watch.html) cli command:

```
consul watch -type=service -service=SOMESERVICE -passingonly=true CHILD_PROC
```

if there is no CHILD_PROC specifiedthen is equivalent to a /v1/catalog/service/SOMESERVICE http api call
If there is a CHILD_PROC defined, its called at every change in the serice state, untill it exits with non zero
- if the service is registered, its full json printed to the STDIN of the CHILD_PROC
- if the service isn't registered an empty json array: [] is sent to CHILD_PROC

So the child process is:

```
bash -c 'cat|grep "\[]"'
```

Which means `consul watch` is running until the service reaches the **passing** state.

Please review: @keyki @martonsereg 
