### PR TITLE
if boot2docker is available than use `boot2docker ip` as consul service ...

### DIFF
--- a/start-cb.sh
+++ b/start-cb.sh
@@ -9,7 +9,7 @@ debug() {
     [[ "$DEBUG" ]] && echo "[DEBUG] $*" 1>&2
 }
 
-BRIDGE_IP=$(docker run --rm gliderlabs/alpine:3.1 ip ro | grep default | cut -d" " -f 3)
+BRIDGE_IP=$(boot2docker ip || (docker run --rm gliderlabs/alpine:3.1 ip ro | grep default | cut -d" " -f 3))
 
 con() {
   declare path="$1"


### PR DESCRIPTION
...ips otherwise use the docker bridge

@akanto please review
We can discuss later this week to use -net=host for consul.
