### PR TITLE
Combined patches

### DIFF
--- a/start-cb.sh
+++ b/start-cb.sh
@@ -281,7 +281,6 @@ start_cloudbreak() {
 
     docker run -d \
         --name=cloudbreak \
-        -e "SERVICE_NAME=cloudbreak" \
         -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
         -e AWS_SECRET_KEY=$AWS_SECRET_KEY \
         -e SERVICE_NAME=cloudbreak \

--- a/start-cb.sh
+++ b/start-cb.sh
@@ -6,7 +6,7 @@
 : ${HOST_ADDRESS:=http://localhost}
 
 : ${DOCKER_TAG_ALPINE:=3.1}
-: ${DOCKER_TAG_CONSUL:=v0.5.0}
+: ${DOCKER_TAG_CONSUL:=v0.5.0-v3}
 : ${DOCKER_TAG_REGISTRATOR:=v5}
 : ${DOCKER_TAG_POSTGRES:=9.4.0}
 : ${DOCKER_TAG_UAA:=1.8.1-v1}
@@ -216,6 +216,7 @@ start_cloudbreak_db() {
     docker run -d -P \
       --name=cbdb \
       -e "SERVICE_NAME=cbdb" \
+      -e SERVICE_CHECK_CMD='psql -h 127.0.0.1 -p 5432  -U postgres -c "select 1"' \
       -v /var/lib/cloudbreak/cbdb:/var/lib/postgresql/data \
       postgres:$DOCKER_TAG_POSTGRES
 
@@ -229,6 +230,7 @@ start_uaa() {
     docker run -d -P \
       --name="uaadb" \
       -e "SERVICE_NAME=uaadb" \
+      -e SERVICE_CHECK_CMD='psql -h 127.0.0.1 -p 5432  -U postgres -c "select 1"' \
       -v /var/lib/cloudbreak/uaadb:/var/lib/postgresql/data \
       postgres:$DOCKER_TAG_POSTGRES
 
@@ -335,6 +337,7 @@ start_periscope_db() {
     docker run -d -P \
       --name=periscopedb \
       -e "SERVICE_NAME=periscopedb" \
+      -e SERVICE_CHECK_CMD='psql -h 127.0.0.1 -p 5432  -U postgres -c "select 1"' \
       -v /var/lib/periscope/periscopedb:/var/lib/postgresql/data \
       postgres:$DOCKER_TAG_POSTGRES
 

--- a/start-cb.sh
+++ b/start-cb.sh
@@ -275,7 +275,7 @@ start_cloudbreak() {
 
     debug $desc
     wait_for_service cbdb
-    export CB_HOST_ADDR=http://$(dh consul):8080
+    export CB_HOST_ADDR=${CLOUDBREAK_PUBLIC_HOST_ADDRESS:=http://$(dh consul):8080}
     cb_envs_to_docker_options
 
     docker run -d \

--- a/start-cb.sh
+++ b/start-cb.sh
@@ -24,8 +24,8 @@ BRIDGE_IP=$(boot2docker ip || (docker run --rm gliderlabs/alpine:3.1 ip ro | gre
 con() {
   declare path="$1"
   shift
-  local consul_ip=$(dig @${BRIDGE_IP} +short consul-8500.service.consul)
-  curl ${consul_ip}:8500/v1/${path} "$@"
+  local consul_ip=$(dig @${BRIDGE_IP} +short consul.service.consul)
+  curl -s ${consul_ip}:8500/v1/${path} "$@"
 }
 
 serv(){

--- a/start-cb.sh
+++ b/start-cb.sh
@@ -343,7 +343,6 @@ start_periscope_db() {
 
     debug "waits for periscopedb get registered in consul"
     wait_for_service periscopedb
-    sleep 20
     debug "periscope db: $(dhp periscopedb) "
 }
 

--- a/start-cb.sh
+++ b/start-cb.sh
@@ -220,7 +220,6 @@ start_cloudbreak_db() {
       postgres:$DOCKER_TAG_POSTGRES
 
     wait_for_service cbdb
-    sleep 20
 }
 
 start_uaa() {
@@ -233,10 +232,7 @@ start_uaa() {
       -v /var/lib/cloudbreak/uaadb:/var/lib/postgresql/data \
       postgres:$DOCKER_TAG_POSTGRES
 
-    debug "waits for uaadb get registered in consul"
     wait_for_service uaadb
-    sleep 20
-    debug "uaa db: $(dhp uaadb) "
 
     docker run -d -P \
       --name="uaa" \
@@ -248,9 +244,7 @@ start_uaa() {
       -p 8089:8080 \
       sequenceiq/uaa:$DOCKER_TAG_UAA
 
-    local uaaaddress=$(docker inspect -f "{{.NetworkSettings.IPAddress}}" uaa):8080/info
-    debug $uaaaddress
-    checkHealthOnUrl $uaaaddress
+    wait_for_service uaa
 }
 
 start_cloudbreak_shell() {
@@ -279,8 +273,7 @@ start_cloudbreak() {
 
     debug $desc
     wait_for_service cbdb
-    debug "cloudbreak db: $(dhp cbdb)"
-    export CB_HOST_ADDR=$CLOUDBREAK_PUBLIC_HOST_ADDRESS
+    export CB_HOST_ADDR=http://$(dh consul):8080
     cb_envs_to_docker_options
 
     docker run -d \
@@ -298,9 +291,7 @@ start_cloudbreak() {
         -p 8080:8080 \
         sequenceiq/cloudbreak:$DOCKER_TAG_CLOUDBREAK bash
 
-    local cbaddress=$(docker inspect -f "{{.NetworkSettings.IPAddress}}" cloudbreak):8080/info
-    debug $cbaddress
-    checkHealthOnUrl $cbaddress
+    wait_for_service cloudbreak
 }
 
 start_uluwatu() {
@@ -399,39 +390,6 @@ bridge_osx() {
     BRIDGE_IP=$(docker run --rm mini/base ip ro | grep default | cut -d" " -f 3)
     sudo networksetup -setdnsservers Wi-Fi 192.168.1.1 $BRIDGE_IP 8.8.8.8
     sudo networksetup -setsearchdomains Wi-Fi service.consul node.consul
-}
-
-checkHealthOnUrl() {
-  declare url=$1
-  declare maxAttempts=10
-  declare pollTimeout=30
-
-  cat <<EOF
-========================================================
-= check service availabilty =
-= by checking the health url:
-=   $url
-=
-= maxAttempts=$maxAttempts
-========================================================
-EOF
-
-  for (( i=1; i<=$maxAttempts; i++ ))
-  do
-      echo "GET $url. Attempt #$i"
-      code=`curl -sL -w "%{http_code}\\n" "$url" -o /dev/null`
-      echo "Found code $code"
-      if [ "x$code" = "x200" ]
-      then
-           echo "Service on '"$url"' is available!"
-           break
-      elif [ $i -eq $maxAttempts ]
-      then
-           echo "Service on '"$url"' not started in time."
-           exit 1
-      fi
-      sleep $pollTimeout
-  done
 }
 
 main() {

--- a/start-cb.sh
+++ b/start-cb.sh
@@ -177,6 +177,7 @@ start_consul() {
     docker run -d \
         -h node1 \
         --name=consul \
+        -e SERVICE_IGNORE=true \
         -p ${BRIDGE_IP}:53:53/udp \
         -p ${BRIDGE_IP}:8400:8400 \
         -p ${BRIDGE_IP}:8500:8500 \

--- a/start-cb.sh
+++ b/start-cb.sh
@@ -19,7 +19,7 @@ debug() {
     [[ "$DEBUG" ]] && echo "[DEBUG] $*" 1>&2
 }
 
-BRIDGE_IP=$(docker run --rm gliderlabs/alpine:3.1 ip ro | grep default | cut -d" " -f 3)
+BRIDGE_IP=$(boot2docker ip || (docker run --rm gliderlabs/alpine:3.1 ip ro | grep default | cut -d" " -f 3))
 
 con() {
   declare path="$1"


### PR DESCRIPTION
this PR replaces https://github.com/sequenceiq/cloudbreak-deployment/pull/7:

define consul health checks via SERVICE_CHECK_HTTP metadata interpreted by registrator
## registrator

See registrator specific metadata explanation: https://github.com/gliderlabs/registrator#basic-http-health-check
## wait for service

The wait_for_service is a [consul watch](https://www.consul.io/docs/commands/watch.html) cli command:

```
consul watch -type=service -service=SOMESERVICE -passingonly=true CHILD_PROC
```

if there is no CHILD_PROC specifiedthen is equivalent to a /v1/catalog/service/SOMESERVICE http api call
If there is a CHILD_PROC defined, its called at every change in the serice state, untill it exits with non zero
- if the service is registered, its full json printed to the STDIN of the CHILD_PROC
- if the service isn't registered an empty json array: [] is sent to CHILD_PROC

So the child process is:

```
bash -c 'cat|grep "\[]"'
```

Which means `consul watch` is running until the service reaches the **passing** state.

Please review: @keyki @martonsereg 
