### PR TITLE
wait for periscope and uluwatu to start

### DIFF
--- a/start-cb.sh
+++ b/start-cb.sh
@@ -311,6 +311,8 @@ start_uluwatu() {
     -e NODE_TLS_REJECT_UNAUTHORIZED=0 \
     -e ULU_PERISCOPE_ADDRESS=http://$(dhp periscope)/ \
     -p 3000:3000 sequenceiq/uluwatu:$DOCKER_TAG_ULUWATU
+
+    wait_for_service uluwatu
 }
 
 start_sultans() {
@@ -341,9 +343,7 @@ start_periscope_db() {
       -v /var/lib/periscope/periscopedb:/var/lib/postgresql/data \
       postgres:$DOCKER_TAG_POSTGRES
 
-    debug "waits for periscopedb get registered in consul"
     wait_for_service periscopedb
-    debug "periscope db: $(dhp periscopedb) "
 }
 
 start_periscope() {
@@ -373,6 +373,8 @@ start_periscope() {
     -e ENDPOINTS_ENV_ENABLED=false \
     -p 8085:8080 \
     sequenceiq/periscope:$DOCKER_TAG_PERISCOPE
+
+    wait_for_service periscope
 }
 
 token() {


### PR DESCRIPTION
@doktoric 

The 'wait_for_service' function is added to start function of Uluwatu and Periscope because: 
- The periscope needs to be registered in Consul before the start of Uluwatu (Uluwatu needs the periscope address).
- I think it is more user-friendly if the script finished then all of the components are ready to use.
